### PR TITLE
feat(agw): Configure Sentry per Python service

### DIFF
--- a/lte/gateway/configs/ctraced.yml
+++ b/lte/gateway/configs/ctraced.yml
@@ -23,3 +23,6 @@ trace_interfaces:
 #   - tshark
 # tshark has more capabilities - see command_builder.py
 trace_tool: tshark
+
+# [Experimental] Enable Sentry for this service
+sentry_enabled: false

--- a/lte/gateway/configs/directoryd.yml
+++ b/lte/gateway/configs/directoryd.yml
@@ -15,3 +15,6 @@
 print_grpc_payload: false
 
 log_level: INFO
+
+# [Experimental] Enable Sentry for this service
+sentry_enabled: false

--- a/lte/gateway/configs/enodebd.yml
+++ b/lte/gateway/configs/enodebd.yml
@@ -46,3 +46,6 @@ web_ui_enable_list: []
 
 # Network interface to terminate S1
 s1_interface: eth1
+
+# [Experimental] Enable Sentry for this service
+sentry_enabled: false

--- a/lte/gateway/configs/eventd.yml
+++ b/lte/gateway/configs/eventd.yml
@@ -60,3 +60,6 @@ event_registry:
   s1_setup_success:
     module: lte
     filename: mme_events.v1.yml
+
+# [Experimental] Enable Sentry for this service
+sentry_enabled: false

--- a/lte/gateway/configs/health.yml
+++ b/lte/gateway/configs/health.yml
@@ -25,3 +25,6 @@ state_recovery:
   interval_check_mins: 3
   # Destination path to save redis RDB temp snapshots
   snapshots_dir: /tmp/redis_snapshots
+
+# [Experimental] Enable Sentry for this service
+sentry_enabled: false

--- a/lte/gateway/configs/kernsnoopd.yml
+++ b/lte/gateway/configs/kernsnoopd.yml
@@ -20,3 +20,6 @@ collect_interval: 10
 ebpf_programs:
   ~
 #  - byte_count
+
+# [Experimental] Enable Sentry for this service
+sentry_enabled: false

--- a/lte/gateway/configs/magmad.yml
+++ b/lte/gateway/configs/magmad.yml
@@ -172,3 +172,6 @@ services_to_restart:
 
 # How many times can grpc status check fail before restarting the services above
 restart_timeout_threshold: 15
+
+# [Experimental] Enable Sentry for this service
+sentry_enabled: false

--- a/lte/gateway/configs/mobilityd.yml
+++ b/lte/gateway/configs/mobilityd.yml
@@ -15,3 +15,6 @@
 persist_to_redis: true
 redis_port: 6380
 print_grpc_payload: false
+
+# [Experimental] Enable Sentry for this service
+sentry_enabled: true

--- a/lte/gateway/configs/monitord.yml
+++ b/lte/gateway/configs/monitord.yml
@@ -13,3 +13,6 @@
 
 # log_level is set in mconfig. it can be overridden here
 mtr_interface: mtr0
+
+# [Experimental] Enable Sentry for this service
+sentry_enabled: false

--- a/lte/gateway/configs/pipelined.yml
+++ b/lte/gateway/configs/pipelined.yml
@@ -215,3 +215,6 @@ sgi_tunnel:
 # dp_tso:
 #   gtp_tso_enable: false
 #
+
+# [Experimental] Enable Sentry for this service
+sentry_enabled: false

--- a/lte/gateway/configs/pipelined.yml_prod
+++ b/lte/gateway/configs/pipelined.yml_prod
@@ -191,3 +191,6 @@ sgi_tunnel:
 # dp_tso:
 #   gtp_tso_enable: false
 #
+
+# [Experimental] Enable Sentry for this service
+sentry_enabled: false

--- a/lte/gateway/configs/policydb.yml
+++ b/lte/gateway/configs/policydb.yml
@@ -34,3 +34,6 @@ bridge_interface: gtp_br0
 # To disable, leave empty
 # If disabled, allows all traffic from the subscribers
 redirect_rule_name:
+
+# [Experimental] Enable Sentry for this service
+sentry_enabled: false

--- a/lte/gateway/configs/redirectd.yml
+++ b/lte/gateway/configs/redirectd.yml
@@ -14,3 +14,6 @@
 # log_level is set in mconfig. it can be overridden here
 
 http_port: 8080
+
+# [Experimental] Enable Sentry for this service
+sentry_enabled: false

--- a/lte/gateway/configs/smsd.yml
+++ b/lte/gateway/configs/smsd.yml
@@ -11,3 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 log_level: INFO
+
+# [Experimental] Enable Sentry for this service
+sentry_enabled: false

--- a/lte/gateway/configs/state.yml
+++ b/lte/gateway/configs/state.yml
@@ -48,3 +48,6 @@ state_protos:
 json_state:
   - redis_key: "directory_record"
     state_scope: "network"
+
+# [Experimental] Enable Sentry for this service
+sentry_enabled: false

--- a/lte/gateway/configs/subscriberdb.yml
+++ b/lte/gateway/configs/subscriberdb.yml
@@ -55,3 +55,6 @@ s6a_over_grpc: True
 
 # Number of thread workers for the gRPC server
 grpc_workers: 10
+
+# [Experimental] Enable Sentry for this service
+sentry_enabled: false

--- a/lte/gateway/python/magma/enodebd/tests/freedomfi_one_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/freedomfi_one_tests.py
@@ -420,6 +420,7 @@ class FreedomFiOneTests(EnodebHandlerTestCase):
                 "sas_location": "indoor",
                 "sas_height_type": "AMSL",
             },
+            "sentry_enabled": False,
         }
 
     def build_freedomfi_one_acs_state_machine(self):

--- a/orc8r/gateway/python/magma/common/sentry.py
+++ b/orc8r/gateway/python/magma/common/sentry.py
@@ -18,6 +18,7 @@ import snowflake
 from magma.configuration.service_configs import get_service_config_value
 
 CONTROL_PROXY = 'control_proxy'
+SENTRY_ENABLED = 'sentry_enabled'
 SENTRY_URL = 'sentry_url_python'
 SENTRY_SAMPLE_RATE = 'sentry_sample_rate'
 COMMIT_HASH = 'COMMIT_HASH'
@@ -27,6 +28,14 @@ SERVICE_NAME = 'service_name'
 
 def sentry_init(service_name: str):
     """Initialize connection and start piping errors to sentry.io."""
+    sentry_enabled = get_service_config_value(
+        service_name,
+        SENTRY_ENABLED,
+        default=False,
+    )
+    if not sentry_enabled:
+        return
+
     sentry_url = get_service_config_value(
         CONTROL_PROXY,
         SENTRY_URL,


### PR DESCRIPTION
## Summary

Make it possible to enable Sentry per Python service.
By default, enable it only for mobilityd.

## Test Plan

Executed loadtest_mobilityd.py with and without Sentry enabled,
including fake error messages that were written for each request.
No performance degradation was observed.