### PR TITLE
chore(eventd): Catch unexpected errors in server in opt-in mode

### DIFF
--- a/orc8r/gateway/python/magma/eventd/rpc_servicer.py
+++ b/orc8r/gateway/python/magma/eventd/rpc_servicer.py
@@ -20,11 +20,17 @@ from typing import Any, Dict
 import grpc
 import jsonschema
 from magma.common.rpc_utils import return_void
+from magma.common.sentry import (
+    SentryStatus,
+    get_sentry_status,
+    send_uncaught_errors_to_monitoring,
+)
 from magma.eventd.event_validator import EventValidator
 from orc8r.protos import eventd_pb2, eventd_pb2_grpc
 
 RETRY_ON_FAILURE = 'retry_on_failure'
 
+enable_sentry_wrapper = get_sentry_status("mobilityd") == SentryStatus.SEND_SELECTED_ERRORS
 
 class EventDRpcServicer(eventd_pb2_grpc.EventServiceServicer):
     """
@@ -44,6 +50,7 @@ class EventDRpcServicer(eventd_pb2_grpc.EventServiceServicer):
         eventd_pb2_grpc.add_EventServiceServicer_to_server(self, server)
 
     @return_void
+    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def LogEvent(self, request: eventd_pb2.Event, context):
         """
         Logs an event.


### PR DESCRIPTION
## Summary

Adds the decorator to catch unexpected errors for gRPC endpoint.

## Context

If Sentry is configured to send only selected errors, this will send unexpected exceptions to Sentry.