### PR TITLE
packaging of magma_dev is adapted

### DIFF
--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -49,7 +49,10 @@
     state: restarted
 
 - name: Install ansible community collection
-  shell: su - {{ ansible_user }} -c 'ansible-galaxy collection install community.general'
+  become: yes
+  become_method: su
+  become_user: {{ ansible_user }}
+  command: ansible-galaxy collection install community.general
   ignore_errors: yes
 
 - name: Set build environment variables

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -11,7 +11,11 @@
 # limitations under the License.
 
 - name: Fix resolve conf
-  shell: ln -sf /var/run/systemd/resolve/resolv.conf /etc/resolv.conf
+  ansible.builtin.file:
+    src: /var/run/systemd/resolve/resolv.conf
+    dest: /etc/resolv.conf
+    state: link
+    force: yes
 
 - name: Include vars of all.yaml
   include_vars:
@@ -477,6 +481,7 @@
     path: '/etc/bazelrc'
     state: link
     force: yes
+    follow: false
 
 - name: Symlink bazel disk cache configuration into the VM
   file:

--- a/orc8r/tools/ansible/roles/pkgrepo/tasks/main.yml
+++ b/orc8r/tools/ansible/roles/pkgrepo/tasks/main.yml
@@ -10,9 +10,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 - name: Remove all old registries
-  shell: rm -rf /etc/apt/sources.list.d/*.list
   become: yes
   ignore_errors: yes
+  ansible.builtin.file:
+    path: /etc/apt/sources.list.d/*.list
+    state: absent
 
 - name: Wait for APT Lock
   shell: |

--- a/orc8r/tools/packer/http/user-data
+++ b/orc8r/tools/packer/http/user-data
@@ -1,0 +1,14 @@
+
+#cloud-config
+autoinstall:
+  version: 1
+  identity:
+    hostname: magma_dev
+    username: vagrant
+    # Generated via: printf vagrant | mkpasswd -m sha-512 -S vagrant. -s
+    password: "$6$vagrant.$sd6r0/OKL.FIGZbhanVkrLassSxoPRv1h5lkISsmBONqaLUGVXkEcD22Ddak5W8JSxeU0VFkU/We1Y7o4hVO/1"
+  early-commands:
+    # otherwise packer tries to connect and exceed max attempts:
+    - systemctl stop ssh
+  ssh:
+    install-server: true

--- a/orc8r/tools/packer/magma-focal-virtualbox.json
+++ b/orc8r/tools/packer/magma-focal-virtualbox.json
@@ -105,8 +105,13 @@
       "type": "shell"
     },
     {
-      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
-      "script": "scripts/setup.sh",
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
+      "scripts": [
+        "scripts/update_ubuntu.sh",
+        "scripts/cleanup_ubuntu.sh",
+        "scripts/minimize_ubuntu.sh"
+      ],
       "type": "shell"
     },
     {
@@ -116,34 +121,20 @@
       "inventory_groups": "focal_dev",
       "playbook_file": "../../../lte/gateway/deploy/magma_dev_focal.yml",
       "role_paths": [
+        "../../../lte/gateway/deploy/roles/dev_common",
+        "../../../lte/gateway/deploy/roles/magma",
+        "../../../lte/gateway/deploy/roles/pyvenv",
         "../../../orc8r/tools/ansible/roles/apt_cache",
-        "../../../orc8r/tools/ansible/roles/distro_snapshot",
         "../../../orc8r/tools/ansible/roles/docker",
         "../../../orc8r/tools/ansible/roles/fluent_bit",
         "../../../orc8r/tools/ansible/roles/gateway_dev",
         "../../../orc8r/tools/ansible/roles/gateway_services",
-        "../../../orc8r/tools/ansible/roles/golang",
         "../../../orc8r/tools/ansible/roles/pkgrepo",
         "../../../orc8r/tools/ansible/roles/python_dev",
-        "../../../orc8r/tools/ansible/roles/resolv_conf",
-        "../../../orc8r/tools/ansible/roles/test_certs",
-        "../../../lte/gateway/deploy/roles/envoy",
-        "../../../lte/gateway/deploy/roles/stretch_snapshot",
-        "../../../lte/gateway/deploy/roles/dev_common",
-        "../../../lte/gateway/deploy/roles/magma",
-        "../../../lte/gateway/deploy/roles/dev_common",
-        "../../../lte/gateway/deploy/roles/magma",
-        "../../../lte/gateway/deploy/roles/magma_test",
-        "../../../lte/gateway/deploy/roles/pyvenv",
-        "../../../lte/gateway/deploy/roles/stretch_snapshot",
-        "../../../lte/gateway/deploy/roles/trfserver",
-        "../../../lte/gateway/deploy/roles/uselocalpkgrepo"
+        "../../../orc8r/tools/ansible/roles/test_certs"
       ],
       "type": "ansible-local"
     }
-  ],
-  "variables": {
-    "cloud_token": "{{ env `ATLAS_TOKEN` }}",
-    "version": "1.0.{{timestamp}}"
-  }
+  ]
 }
+

--- a/orc8r/tools/packer/scripts/cleanup_ubuntu.sh
+++ b/orc8r/tools/packer/scripts/cleanup_ubuntu.sh
@@ -1,0 +1,92 @@
+#!/bin/sh -eux
+################################################################################
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+
+echo "remove linux-headers"
+dpkg --list \
+  | awk '{ print $2 }' \
+  | grep 'linux-headers' \
+  | grep -v `uname -r` \
+  | xargs apt-get -y purge;
+
+echo "remove specific Linux kernels, such as linux-image-3.11.0-15-generic but keeps the current kernel and does not touch the virtual packages"
+dpkg --list \
+    | awk '{ print $2 }' \
+    | grep 'linux-image-.*-generic' \
+    | grep -v `uname -r` \
+    | xargs apt-get -y purge;
+
+echo "remove old kernel modules packages"
+dpkg --list \
+    | awk '{ print $2 }' \
+    | grep 'linux-modules-.*-generic' \
+    | grep -v `uname -r` \
+    | xargs apt-get -y purge;
+
+echo "remove linux-source package"
+dpkg --list \
+    | awk '{ print $2 }' \
+    | grep linux-source \
+    | xargs apt-get -y purge;
+
+echo "remove docs packages"
+dpkg --list \
+    | awk '{ print $2 }' \
+    | grep -- '-doc$' \
+    | xargs apt-get -y purge;
+
+echo "remove X11 libraries"
+apt-get -y purge libx11-data xauth libxmuu1 libxcb1 libx11-6 libxext6;
+
+echo "remove packages we don't need"
+apt-get -y purge popularity-contest command-not-found friendly-recovery bash-completion laptop-detect usbutils
+
+# Exclude the files we don't need w/o uninstalling linux-firmware
+echo "Setup dpkg excludes for linux-firmware"
+cat <<_EOF_ | cat >> /etc/dpkg/dpkg.cfg.d/excludes
+#UNINSTALL-BEGIN
+path-exclude=/lib/firmware/*
+path-exclude=/usr/share/doc/linux-firmware/*
+#UNINSTALL-END
+_EOF_
+
+echo "delete the massive firmware files"
+rm -rf /lib/firmware/*
+rm -rf /usr/share/doc/linux-firmware/*
+
+echo "autoremoving packages and cleaning apt data"
+apt-get -y autoremove;
+apt-get -y clean;
+
+echo "remove /usr/share/doc/"
+rm -rf /usr/share/doc/*
+
+echo "remove /var/cache"
+find /var/cache -type f -exec rm -rf {} \;
+
+echo "truncate any logs that have built up during the install"
+find /var/log -type f -exec truncate --size=0 {} \;
+
+echo "blank netplan machine-id (DUID) so machines get unique ID generated on boot"
+truncate -s 0 /etc/machine-id
+
+echo "remove the contents of /tmp and /var/tmp"
+rm -rf /tmp/* /var/tmp/*
+
+echo "force a new random seed to be generated"
+rm -f /var/lib/systemd/random-seed
+
+echo "clear the history so our install isn't there"
+rm -f /root/.wget-hsts
+export HISTSIZE=0

--- a/orc8r/tools/packer/scripts/minimize_ubuntu.sh
+++ b/orc8r/tools/packer/scripts/minimize_ubuntu.sh
@@ -1,0 +1,49 @@
+#!/bin/sh -eux
+################################################################################
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+case "$PACKER_BUILDER_TYPE" in
+  qemu) exit 0 ;;
+esac
+
+# Whiteout root
+count=$(df --sync -kP / | tail -n1  | awk -F ' ' '{print $4}')
+count=$(($count-1))
+dd if=/dev/zero of=/tmp/whitespace bs=1M count=$count || echo "dd exit code $? is suppressed";
+rm /tmp/whitespace
+
+# Whiteout /boot
+count=$(df --sync -kP /boot | tail -n1 | awk -F ' ' '{print $4}')
+count=$(($count-1))
+dd if=/dev/zero of=/boot/whitespace bs=1M count=$count || echo "dd exit code $? is suppressed";
+rm /boot/whitespace
+
+set +e
+swapuuid="`/sbin/blkid -o value -l -s UUID -t TYPE=swap`";
+case "$?" in
+    2|0) ;;
+    *) exit 1 ;;
+esac
+set -e
+
+if [ "x${swapuuid}" != "x" ]; then
+    # Whiteout the swap partition to reduce box size
+    # Swap is disabled till reboot
+    swappart="`readlink -f /dev/disk/by-uuid/$swapuuid`";
+    /sbin/swapoff "$swappart" || true;
+    dd if=/dev/zero of="$swappart" bs=1M || echo "dd exit code $? is suppressed";
+    /sbin/mkswap -U "$swapuuid" "$swappart";
+fi
+
+sync;
+reboot;

--- a/orc8r/tools/packer/scripts/ubuntu_setup.sh
+++ b/orc8r/tools/packer/scripts/ubuntu_setup.sh
@@ -21,7 +21,10 @@ sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
 echo 'APT::Periodic::Enable "0";' >> /etc/apt/apt.conf.d/10periodic
 
 apt update
-apt install -y ansible
+apt install -y software-properties-common
+add-apt-repository ppa:ansible/ansible
+apt update
+apt install -y ansible=5.10.0-1ppa~focal
 
 # Mount the guest additions iso and run the install script
 mkdir -p /mnt/iso

--- a/orc8r/tools/packer/scripts/update_ubuntu.sh
+++ b/orc8r/tools/packer/scripts/update_ubuntu.sh
@@ -1,0 +1,44 @@
+#!/bin/sh -eux
+################################################################################
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Update the package list
+apt-get -y update;
+
+# Disable systemd apt timers/services
+systemctl stop apt-daily.timer;
+systemctl stop apt-daily-upgrade.timer;
+systemctl disable apt-daily.timer;
+systemctl disable apt-daily-upgrade.timer;
+systemctl mask apt-daily.service;
+systemctl mask apt-daily-upgrade.service;
+systemctl daemon-reload;
+
+# Disable periodic activities of apt to be safe
+cat <<EOF >/etc/apt/apt.conf.d/10periodic;
+APT::Periodic::Enable "0";
+APT::Periodic::Update-Package-Lists "0";
+APT::Periodic::Download-Upgradeable-Packages "0";
+APT::Periodic::AutocleanInterval "0";
+APT::Periodic::Unattended-Upgrade "0";
+EOF
+
+# Clean and nuke the package from orbit
+rm -rf /var/log/unattended-upgrades;
+apt-get -y purge unattended-upgrades;
+
+# Upgrade all installed packages incl. kernel and kernel headers
+apt-get -y dist-upgrade -o Dpkg::Options::="--force-confnew";
+reboot;


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

## Summary

The scripts involved with packing the magma_dev VM via `packer` are adapted to Ubuntu's switch to UEFI boot. 

1. The VM get's an incremental update to Ubuntu 20.04.4
2. The `boot_command` for unattended installation is adapted to the UEFI boot mode
3. Some general house keeping the `.yml`
4. Additional scripts to for a tidy Ubuntu-based VM are added

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
