### PR TITLE
chore(ci): make focal basebox fast again

### DIFF
--- a/orc8r/tools/packer/magma-focal-virtualbox.json
+++ b/orc8r/tools/packer/magma-focal-virtualbox.json
@@ -28,7 +28,7 @@
       ],
       "boot_wait": "5s",
       "guest_additions_mode": "upload",
-      "guest_os_type": "ubuntu-64",
+      "guest_os_type": "Ubuntu_64",
       "headless": true,
       "http_directory": "http",
       "iso_checksum": "sha256:f11bda2f2caed8f420802b59f382c25160b114ccc665dbac9c5046e7fceaced2",


### PR DESCRIPTION
it was just a typo: `ubuntu-64` -> `Ubuntu_64`

* [guest_os_type](https://www.packer.io/plugins/builders/virtualbox/iso#guest_os_type) (string) - The guest OS type being installed. By default this is other, but you can get dramatic performance improvements by setting this to the proper value. To view all available values for this run VBoxManage list ostypes. Setting the correct value hints to VirtualBox how to optimize the virtual hardware to work best with that operating system.